### PR TITLE
remove the redundant alert when recasting the spell

### DIFF
--- a/src/main/java/com/portaguy/ThrallHelperPlugin.java
+++ b/src/main/java/com/portaguy/ThrallHelperPlugin.java
@@ -3,11 +3,21 @@ package com.portaguy;
 import com.google.inject.Provides;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.Notifier;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -27,9 +37,19 @@ public class ThrallHelperPlugin extends Plugin
 	private static final String RESURRECT_THRALL_MESSAGE_END = " thrall.</col>";
 	private static final String RESURRECT_THRALL_DISAPPEAR_MESSAGE_START = ">Your ";
 	private static final String RESURRECT_THRALL_DISAPPEAR_MESSAGE_END = " thrall returns to the grave.</col>";
+	private static final String SPELL_TARGET_REGEX = "<col=00ff00>Resurrect (Greater|Superior|Lesser) (Skeleton|Ghost|Zombie)</col>";
+	private static final Pattern SPELL_TARGET_PATTERN = Pattern.compile(SPELL_TARGET_REGEX);
 	private static final int SPELLBOOK_VARBIT = 4070;
 	private static final int ARCEUUS_SPELLBOOK = 3;
+	private static final Set<Integer> activeSpellSpriteIds = new HashSet<>(Arrays.asList(
+			// Ghost, Skeleton, Zombie
+			2980, 2982, 2984, 	// Greater
+			2979, 2981, 2983,	// Superior
+			1270, 1271, 1300	// Lesser
+	));
+
 	private Instant last_thrall_summoned;
+	private boolean isSpellClicked = false;
 
 	@Inject
 	private Notifier notifier;
@@ -101,16 +121,57 @@ public class ThrallHelperPlugin extends Plugin
 		{
 			overlayManager.remove(overlay);
 			last_thrall_summoned = Instant.now();
+			isSpellClicked = false;
 		}
 		if (message.contains(RESURRECT_THRALL_DISAPPEAR_MESSAGE_START) && message.endsWith((RESURRECT_THRALL_DISAPPEAR_MESSAGE_END)))
 		{
-			overlayManager.add(overlay);
-			if (config.shouldNotify())
+			// If the spell has been cast there is no need to notify
+			if (!isSpellClicked)
 			{
-				notifier.notify("You need to summon a thrall!");
+				overlayManager.add(overlay);
+				if (config.shouldNotify())
+				{
+					notifier.notify("You need to summon a thrall!");
+				}
 			}
 		}
+	}
 
+	@Subscribe
+	public void onMenuOptionClicked(MenuOptionClicked event)
+	{
+		// Check the menu option clicked is one of the resurrection spells
+		Matcher matcher = SPELL_TARGET_PATTERN.matcher(event.getMenuTarget());
+		if (!matcher.matches())
+		{
+			return;
+		}
+		// If the user doesn't have the book then they can't cast the spell
+		if (!hasBookOfTheDead())
+		{
+			return;
+		}
+		Widget widget = event.getWidget();
+		if (widget == null)
+		{
+			return;
+		}
+		// In the 10-second cool down where the spell can't recast the opacity changes from 0 to 150
+		if (activeSpellSpriteIds.contains(widget.getSpriteId()) && widget.getOpacity() == 0)
+		{
+			isSpellClicked = true;
+		}
+	}
+
+	private boolean hasBookOfTheDead()
+	{
+		ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
+		ItemContainer equipment = client.getItemContainer(InventoryID.EQUIPMENT);
+		if (inventory == null || equipment == null)
+		{
+			return false;
+		}
+		return inventory.contains(ItemID.BOOK_OF_THE_DEAD) || equipment.contains(ItemID.BOOK_OF_THE_DEAD);
 	}
 
 	@Provides


### PR DESCRIPTION
Whenever the spell is castable and one of the spell icons is clicked, the following alert is skipped.

https://user-images.githubusercontent.com/85463994/194217166-52090fb8-432a-43a0-86be-d5a696b9383d.mp4

Fixes https://github.com/PortAGuy/thrall-helper/issues/5