### PR TITLE
Fire thrall notification immediately when entering a new instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,14 @@ tasks.withType(JavaCompile).configureEach {
     options.release.set(11)
 }
 
+tasks.register('run', JavaExec) {
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'com.portaguy.SpellReminderPluginTest'
+
+    jvmArgs "-ea"
+    args "--developer-mode", "--debug"
+}
+
 tasks.register('shadowJar', Jar) {
     dependsOn configurations.testRuntimeClasspath
     manifest {

--- a/src/main/java/com/portaguy/SpellReminderConfig.java
+++ b/src/main/java/com/portaguy/SpellReminderConfig.java
@@ -143,10 +143,21 @@ public interface SpellReminderConfig extends Config {
   }
 
   @ConfigItem(
+      keyName = "thrallNotifyOnInstanceEnter",
+      name = "Notify Immediately on Entering New Instance",
+      description = "Show the thrall reminder immediately when entering a new instance, hides again if reentering area thrall was summoned in.",
+      position = 4,
+      section = THRALL_SECTION
+  )
+  default boolean thrallNotifyOnInstanceEnter() {
+    return false;
+  }
+
+  @ConfigItem(
       keyName = "hideReminderHotkey",
       name = "Hide Reminder Hotkey",
       description = "Sets a hotkey to instantly hide the reminder box.",
-      position = 4,
+      position = 5,
       section = THRALL_SECTION
   )
   default Keybind hideReminderHotkey() {
@@ -157,7 +168,7 @@ public interface SpellReminderConfig extends Config {
       keyName = "reminderStyle",
       name = "Reminder style",
       description = "Changes the style of the reminder box",
-      position = 5,
+      position = 6,
       section = THRALL_SECTION
   )
   default SpellReminderStyle reminderStyle() {
@@ -168,7 +179,7 @@ public interface SpellReminderConfig extends Config {
       keyName = "customText",
       name = "Custom Text",
       description = "Changes the text in the reminder box if the style is set to custom text",
-      position = 6,
+      position = 7,
       section = THRALL_SECTION
   )
   default String customText() {
@@ -179,7 +190,7 @@ public interface SpellReminderConfig extends Config {
       keyName = "shouldFlash",
       name = "Flash the Reminder Box",
       description = "Makes the reminder box flash between the defined colors.",
-      position = 7,
+      position = 8,
       section = THRALL_SECTION
   )
   default boolean shouldFlash() {
@@ -191,7 +202,7 @@ public interface SpellReminderConfig extends Config {
       keyName = "flashColor2",
       name = "Color",
       description = "The second color to flash between.",
-      position = 8,
+      position = 9,
       section = THRALL_SECTION
   )
   default Color color() {
@@ -203,7 +214,7 @@ public interface SpellReminderConfig extends Config {
       keyName = "flashColor1",
       name = "Flash Color",
       description = "The first color to flash between, also controls the non-flashing color.",
-      position = 9,
+      position = 10,
       section = THRALL_SECTION
   )
   default Color flashColor() {
@@ -214,7 +225,7 @@ public interface SpellReminderConfig extends Config {
       keyName = "reminderRegex",
       name = "Remind on Regex",
       description = "Displays the reminder box upon a chat message matching the regex.",
-      position = 10,
+      position = 11,
       section = THRALL_SECTION
   )
   default String notifyRegex() {
@@ -225,7 +236,7 @@ public interface SpellReminderConfig extends Config {
       keyName = "hiderRegex",
       name = "Hide on Regex",
       description = "Hides the reminder (if active) upon a chat message matching the regex.",
-      position = 11,
+      position = 12,
       section = THRALL_SECTION
   )
   default String removeRegex() {
@@ -236,7 +247,7 @@ public interface SpellReminderConfig extends Config {
       keyName = "matchGameMessagesOnly",
       name = "Only Match Game Messages",
       description = "Only attempt to match game messages with the regex.",
-      position = 12,
+      position = 13,
       section = THRALL_SECTION
   )
   default boolean matchGameMessagesOnly() {

--- a/src/main/java/com/portaguy/SpellReminderPlugin.java
+++ b/src/main/java/com/portaguy/SpellReminderPlugin.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.WorldView;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
@@ -23,6 +24,7 @@ import net.runelite.client.events.ConfigChanged;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 
@@ -45,8 +47,13 @@ import java.util.regex.Matcher;
   configName = "ThrallHelperPlugin"
 )
 public class SpellReminderPlugin extends Plugin {
+  // ignore regions where summoning a thrall early is not useful (whisperer & sotetseg maze)
+  private static final int[] INSTANCE_RESET_IGNORED_REGIONS = { 10595, 13379 };
+
   private SharedKeyListener keyListener;
   private final List<SpellTracker> spellTrackers = new ArrayList<>();
+  private int[] previousRegions = null;
+  private boolean wasInInstance = false;
 
   @Inject
   protected ThrallTracker thrallTracker;
@@ -232,6 +239,81 @@ public class SpellReminderPlugin extends Plugin {
           .runeLiteFormattedMessage(SpellReminderConfig.thrallHelperToSpellReminderUpdateText).build());
       configManager.setConfiguration(SpellReminderConfig.GROUP, "thrallHelperToSpellReminderUpdate", true);
     }
+
+    resetThrallTimerIfEnteringANewInstance();
+  }
+
+  private void resetThrallTimerIfEnteringANewInstance() {
+    WorldView wv = client.getTopLevelWorldView();
+    if (wv == null)
+    {
+      return;
+    }
+
+    boolean inInstance = wv.isInstance();
+    int[] regions = wv.getMapRegions();
+
+    boolean isActive = thrallTracker.isActive();
+    boolean hasSavedTimer = thrallTracker.hasResumeData();
+
+    if (isActive || hasSavedTimer)
+    {
+      boolean enteredFromNonInstance = !wasInInstance;
+      boolean changedInstance = wasInInstance && !regionsMatch(previousRegions, regions);
+
+      if (enteredFromNonInstance || changedInstance)
+      {
+        if (regionsMatch(regions, thrallTracker.getSummonRegions()))
+        {
+          if (hasSavedTimer)
+          {
+            thrallTracker.resumeCountdown();
+          }
+        }
+        else if (inInstance && !isInstanceResetIgnored(regions))
+        {
+          if (isActive)
+          {
+            thrallTracker.saveForResume(thrallTracker.getFinalTick());
+            if (config.thrallNotifyOnInstanceEnter())
+            {
+              thrallTracker.stop();
+            }
+          }
+        }
+      }
+    }
+
+    wasInInstance = inInstance;
+    previousRegions = inInstance ? regions.clone() : null;
+  }
+
+  private boolean regionsMatch(int[] a, int[] b)
+  {
+    if (a == null || b == null)
+    {
+      return false;
+    }
+    int[] sortedA = a.clone();
+    int[] sortedB = b.clone();
+    Arrays.sort(sortedA);
+    Arrays.sort(sortedB);
+    return Arrays.equals(sortedA, sortedB);
+  }
+
+  private boolean isInstanceResetIgnored(int[] regions)
+  {
+    for (int region : regions)
+    {
+      for (int ignored : INSTANCE_RESET_IGNORED_REGIONS)
+      {
+        if (region == ignored)
+        {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   @Subscribe

--- a/src/main/java/com/portaguy/trackers/ThrallTracker.java
+++ b/src/main/java/com/portaguy/trackers/ThrallTracker.java
@@ -3,7 +3,9 @@ package com.portaguy.trackers;
 import com.portaguy.*;
 import com.portaguy.infoboxes.ThrallInfobox;
 import com.portaguy.overlays.ThrallOverlay;
+import lombok.Getter;
 import net.runelite.api.Skill;
+import net.runelite.api.WorldView;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.config.Keybind;
@@ -18,6 +20,10 @@ public class ThrallTracker extends SpellTracker {
 
   @Inject
   protected ThrallInfobox infobox;
+
+  @Getter
+  private int[] summonRegions;
+  private int savedFinalTick = -1;
 
   @Inject
   public ThrallTracker() {
@@ -43,6 +49,24 @@ public class ThrallTracker extends SpellTracker {
 
       // Thralls take 4 ticks from summon to become active
       start(ticks + 4);
+
+      savedFinalTick = -1;
+      WorldView wv = client.getTopLevelWorldView();
+      summonRegions = wv != null ? wv.getMapRegions().clone() : null;
+    }
+  }
+
+  public boolean hasResumeData() { return savedFinalTick != -1; }
+
+  public void saveForResume(int absoluteFinalTick) { savedFinalTick = absoluteFinalTick; }
+
+  public void resumeCountdown()
+  {
+    int remaining = savedFinalTick - client.getTickCount();
+    savedFinalTick = -1;
+    if (remaining > 0)
+    {
+      start(remaining);
     }
   }
 


### PR DESCRIPTION
One problem I had with this plugin was forgetting to re-summon my thrall when entering a new floor at Doom or when transitioning between P2 and P3 at Wardens.

This PR checks if you are entering a new instance and stops the timer immediately.

There is also an ignored region list that includes The Whisperer and Sotetseg's maze, where force summoning a thrall in that instance is not beneficial to the user.